### PR TITLE
Add GitHub Action for build verification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build and Verify
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18.17.1'
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.npm
+            node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build

--- a/package.json
+++ b/package.json
@@ -29,5 +29,10 @@
     "tailwind-merge": "^2.6.0",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.2"
+  },
+  "devDependencies": {
+    "@actions/core": "^1.10.0",
+    "@actions/github": "^5.1.1",
+    "@vercel/ncc": "^0.34.0"
   }
 }


### PR DESCRIPTION
Add a GitHub Action workflow to build and verify the site on push and pull request events.

* **Workflow Configuration**
  - Define a new workflow in `.github/workflows/build.yml`.
  - Set the workflow to trigger on push to the main branch and on pull requests.
  - Use Node.js version 18.17.1.
  - Include steps to checkout the repository, cache dependencies, install dependencies, and run the build command.

* **Dependencies**
  - Add `@actions/core`, `@actions/github`, and `@vercel/ncc` as devDependencies in `package.json`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/YOUSIKI/sikimoe/pull/3?shareId=f4d018c5-c898-47a0-9964-434815e6c29d).