### PR TITLE
Deploy from GitHub Actions: main previews, releases publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,13 @@ jobs:
       # deploy needs the repository as well as the build output.
       - uses: actions/checkout@v7
 
+      # bun.lock makes wrangler-action reach for bun whether or not
+      # `packageManager` says so, and the runner has no bun until this runs.
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
       - name: Download dist/
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,13 @@
 name: CI
 
+# Verify everything, then publish a *preview version* of it. Nothing here can
+# change what siki.moe serves: `wrangler versions upload` has no `--routes`,
+# `--domain` or `--triggers` flag, so it cannot apply the `custom_domain` entry
+# in wrangler.jsonc. Only `wrangler deploy` can, and only release.yml runs it.
+
 on:
   push:
-    branches: [main, redesign]
+    branches: [main]
   pull_request:
   workflow_dispatch:
 
@@ -15,32 +20,88 @@ permissions:
 
 jobs:
   verify:
-    name: Lint, typecheck, test, build
+    uses: ./.github/workflows/verify.yml
+    with:
+      artifact: dist-${{ github.sha }}
+    secrets: inherit
+
+  preview:
+    name: Upload preview version
+    needs: verify
+    # A pull request from a fork cannot read the Cloudflare secrets, so there is
+    # nothing it could upload — skip it rather than fail the run.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+    environment:
+      name: preview
+      url: ${{ steps.alias.outputs.url }}
 
     steps:
-      - uses: actions/checkout@v5
+      # wrangler.jsonc is what names the Worker and points at ./dist, so the
+      # deploy needs the repository as well as the build output.
+      - uses: actions/checkout@v7
 
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Download dist/
+        uses: actions/download-artifact@v8
         with:
-          bun-version-file: .bun-version
+          name: dist-${{ github.sha }}
+          path: dist
 
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      # An alias becomes a DNS label, so `<alias>-siki-moe` has to fit in 63
+      # characters and stay lowercase. A branch name would not reliably do
+      # either; a PR number always does. The resulting URL is deterministic,
+      # which is why it can be computed here instead of scraped from wrangler's
+      # output. `yousiki` is the account's workers.dev subdomain.
+      - name: Resolve preview alias
+        id: alias
+        env:
+          EVENT: ${{ github.event_name }}
+          NUMBER: ${{ github.event.number }}
+        run: |
+          if [ "$EVENT" = "pull_request" ]; then
+            alias="pr-$NUMBER"
+          else
+            alias="main"
+          fi
+          echo "alias=$alias" >> "$GITHUB_OUTPUT"
+          echo "url=https://$alias-siki-moe.yousiki.workers.dev" >> "$GITHUB_OUTPUT"
 
-      - name: Check formatting
-        run: bun run format:check
+      # The message is built from the alias and the commit SHA only. Both are
+      # safe to interpolate into a command line; a branch name or PR title is
+      # not, and neither is worth a shell injection.
+      - name: Upload version
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          packageManager: bun
+          # Pinned to the major so a wrangler release cannot change deploy
+          # behaviour unannounced, while patches still arrive.
+          wranglerVersion: '4'
+          command: >-
+            versions upload
+            --preview-alias ${{ steps.alias.outputs.alias }}
+            --message "${{ steps.alias.outputs.alias }} @ ${{ github.sha }}"
 
-      - name: Lint
-        run: bun run lint
-
-      - name: Typecheck
-        run: bun run check
-
-      - name: Unit tests
-        run: bun run test
-
-      - name: Build
-        run: bun run build
+      # One comment per pull request, edited in place on every push, so the
+      # thread does not fill up with dead links.
+      - name: Comment the preview link
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUMBER: ${{ github.event.number }}
+          URL: ${{ steps.alias.outputs.url }}
+        run: |
+          {
+            echo "**Preview:** $URL"
+            echo
+            echo "Built from \`$GITHUB_SHA\`. siki.moe is unaffected — only"
+            echo "publishing a GitHub Release deploys to production."
+          } > comment.md
+          gh pr comment "$NUMBER" --edit-last --create-if-none --body-file comment.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,13 @@ jobs:
       # the deploy needs the repository as well as the build output.
       - uses: actions/checkout@v7
 
+      # bun.lock makes wrangler-action reach for bun whether or not
+      # `packageManager` says so, and the runner has no bun until this runs.
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
       - name: Download dist/
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release
+
+# Publishing a GitHub Release is the only thing that changes what siki.moe
+# serves. Pushing to `main` produces a preview version and nothing more.
+#
+# `workflow_dispatch` is the escape hatch: it deploys whatever ref you pick,
+# which is how the site gets restored if a release goes out broken and there is
+# no good version to roll back to.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+# Never cancel a production deploy in flight — an interrupted one can leave the
+# active version and the release describing it out of step.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    uses: ./.github/workflows/verify.yml
+    with:
+      artifact: dist-${{ github.sha }}
+    secrets: inherit
+
+  deploy:
+    name: Deploy to siki.moe
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: production
+      url: https://siki.moe
+
+    steps:
+      # wrangler.jsonc carries the Worker name and the `custom_domain` route, so
+      # the deploy needs the repository as well as the build output.
+      - uses: actions/checkout@v7
+
+      - name: Download dist/
+        uses: actions/download-artifact@v8
+        with:
+          name: dist-${{ github.sha }}
+          path: dist
+
+      # A tag name is author-controlled text on its way to a command line, so it
+      # is reduced to characters that cannot escape a shell word before use.
+      - name: Resolve deployment message
+        id: message
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          tag="$(printf '%s' "${TAG:-}" | tr -cd 'A-Za-z0-9._-')"
+          echo "text=release ${tag:-manual} ($GITHUB_SHA)" >> "$GITHUB_OUTPUT"
+
+      # `deploy`, not `versions upload`: this is the only command that applies
+      # the `routes` entry, and therefore the only one that can attach siki.moe.
+      # On a first run it also writes the DNS record and turns off workers.dev.
+      - name: Deploy
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          packageManager: bun
+          wranglerVersion: '4'
+          command: deploy --message "${{ steps.message.outputs.text }}"
+
+      # A deploy that reports success while the domain answers 5xx is the failure
+      # mode worth catching, so the job does not go green until siki.moe does.
+      # The retries cover certificate issuance on a freshly attached domain.
+      - name: Smoke check siki.moe
+        run: |
+          for _ in $(seq 1 20); do
+            code="$(curl -sS -o /dev/null -w '%{http_code}' https://siki.moe || true)"
+            if [ "$code" = "200" ]; then
+              echo "siki.moe answered 200"
+              exit 0
+            fi
+            echo "siki.moe answered ${code:-nothing}, retrying"
+            sleep 9
+          done
+          echo "::error::siki.moe never answered 200 after the deploy"
+          exit 1

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,72 @@
+name: Verify
+
+# The single definition of "good enough to ship". Both `ci.yml` and `release.yml`
+# call it, so a preview and a production deploy are gated on exactly the same
+# checks — and `dist/` is built once here and handed to whichever deploy job
+# asked for it, so the bytes that were verified are the bytes that ship.
+
+on:
+  workflow_call:
+    inputs:
+      artifact:
+        description: Name to upload the built dist/ under. Empty skips the upload.
+        type: string
+        default: ''
+    secrets:
+      CV_GITHUB_TOKEN:
+        description: Read access to yousiki/resume, so the build picks up the newest CV.
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Lint, typecheck, test, build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Check formatting
+        run: bun run format:check
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Typecheck
+        run: bun run check
+
+      - name: Unit tests
+        run: bun run test
+
+      # `public/cv/` is committed, so this builds without the secret — it just
+      # ships the CV as of the last `bun run cv` instead of the newest release.
+      # See scripts/sync-cv.ts, which warns and exits 0 when the copies are there.
+      - name: Build
+        run: bun run build
+        env:
+          CV_GITHUB_TOKEN: ${{ secrets.CV_GITHUB_TOKEN }}
+
+      - name: Upload dist/
+        if: inputs.artifact != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.artifact }}
+          path: dist
+          retention-days: 7
+          # A missing or silently-thinned artifact would deploy as a green build,
+          # so fail loudly instead: `if-no-files-found` catches an empty `dist/`,
+          # and `include-hidden-files` stops the upload from dropping anything
+          # dot-prefixed the site may grow later (`.well-known/`, say).
+          if-no-files-found: error
+          include-hidden-files: true

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ bun run cv            # pull the latest release into public/cv/
 `bun run build` runs it first, so a deploy always ships the newest CV it can
 reach. The PDFs are committed, like `public/og.png` — a build with no GitHub
 credentials keeps the vendored copies and only warns. `SKIP_CV_SYNC=1` skips the
-sync entirely. Authentication is `gh auth login` locally, or `CV_GITHUB_TOKEN` as
-a build variable in Cloudflare.
+sync entirely. Authentication is `gh auth login` locally, or a `CV_GITHUB_TOKEN`
+repository secret in CI.
 
 Regenerate the social card after changing the name, role, or palette:
 
@@ -121,27 +121,46 @@ declared in [`wrangler.jsonc`](wrangler.jsonc) as a `routes` entry with
 deploy. `siki.moe` is therefore version-controlled rather than a dashboard
 setting nobody remembers clicking. Pages has no equivalent field.
 
-Cloudflare builds and deploys straight from this repository — Workers Builds,
-connected to `main`:
+GitHub Actions does the deploying — not Workers Builds, which must stay
+disconnected from this repository or the two will publish over each other.
 
-| Build setting  | Value                 |
-| -------------- | --------------------- |
-| Build command  | `bun run build`       |
-| Deploy command | `npx wrangler deploy` |
-| Git branch     | `main`                |
-| Build variable | `CV_GITHUB_TOKEN`     |
+| Trigger                  | Workflow      | Command                    | Result                                |
+| ------------------------ | ------------- | -------------------------- | ------------------------------------- |
+| Pull request             | `ci.yml`      | `wrangler versions upload` | `pr-<n>-siki-moe.yousiki.workers.dev` |
+| Push to `main`           | `ci.yml`      | `wrangler versions upload` | `main-siki-moe.yousiki.workers.dev`   |
+| GitHub Release published | `release.yml` | `wrangler deploy`          | `siki.moe`                            |
 
-So **every push to `main` publishes**. There is no manual gate and no deploy
-workflow; `.github/workflows/ci.yml` runs format, lint, typecheck, unit tests and
-build on every push and pull request, and that is all GitHub does. Nothing waits
-for it — keep `bun run verify` green before pushing.
+So **`main` no longer publishes**. Only a release does, and only through
+`wrangler deploy` — the one command that applies the `routes` entry above.
+`wrangler versions upload` has no `--routes`, `--domain` or `--triggers` flag, so
+a preview is structurally incapable of touching `siki.moe`; that guarantee comes
+from the command rather than from a conditional someone could get wrong.
 
-`CV_GITHUB_TOKEN` is a _build_ variable, not a runtime one. Without it the build
-keeps the CV PDFs committed to `public/cv/` and only warns.
+Both workflows call [`verify.yml`](.github/workflows/verify.yml) first, so a
+deploy is gated on the same format, lint, typecheck, test and build run that a
+pull request gets, and `dist/` is built exactly once and handed on as an
+artifact — the bytes that were verified are the bytes that ship.
 
-To preview a branch instead of publishing it, enable non-production branch builds
-and set that deploy command to `npx wrangler versions upload`, which returns a
-preview URL without touching the active deployment.
+`workflow_dispatch` on `release.yml` deploys whichever ref you pick, which is how
+the site gets restored when there is no good version to roll back to. To roll
+back to one that exists:
+
+```bash
+wrangler versions list --name siki-moe
+wrangler versions deploy <version-id>@100% -y
+```
+
+Two repository secrets are required. `CLOUDFLARE_ACCOUNT_ID`, and a
+`CLOUDFLARE_API_TOKEN` holding Workers Scripts: Edit and Account Settings: Read
+on the account, plus Workers Routes: Edit and DNS: Edit on the `siki.moe` zone —
+the last one because `custom_domain` writes the DNS record itself.
+
+`CV_GITHUB_TOKEN` is optional, and a _build_ secret rather than a runtime one.
+Without it the build keeps the CV PDFs committed to `public/cv/` and only warns.
+
+`workers_dev` is off so the site answers on `siki.moe` and nowhere else;
+`preview_urls` has to then be turned back on explicitly, because it defaults to
+whatever `workers_dev` is. Only `wrangler deploy` writes either setting.
 
 `public/_headers` sets a strict Content-Security-Policy and immutable caching for
 fingerprinted assets; Workers parses it rather than serving it, and applies it at

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "@tailwindcss/vite": "^4.3.3",
         "astro": "^7.2.0",
         "lenis": "^1.3.26",
-        "motion": "^13.0.0",
+        "motion": "^13.1.0",
         "tailwindcss": "^4.3.3",
       },
       "devDependencies": {
@@ -23,13 +23,13 @@
         "eslint": "^10.8.1",
         "eslint-plugin-astro": "^3.1.0",
         "globals": "^17.9.0",
-        "jiti": "^2.6.1",
+        "jiti": "^2.7.0",
         "prettier": "^3.9.6",
         "prettier-plugin-astro": "^0.14.1",
         "prettier-plugin-tailwindcss": "^0.8.1",
         "sharp": "^0.35.3",
-        "typescript": "^5.9.3",
-        "typescript-eslint": "^8.54.0",
+        "typescript": "^6.0.3",
+        "typescript-eslint": "^8.67.0",
         "vitest": "^4.1.10",
         "wrangler": "^4.120.0",
       },
@@ -416,23 +416,23 @@
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
-    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.66.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.66.0", "@typescript-eslint/type-utils": "8.66.0", "@typescript-eslint/utils": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.66.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A=="],
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.67.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.67.0", "@typescript-eslint/type-utils": "8.67.0", "@typescript-eslint/utils": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.67.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ=="],
 
     "@typescript-eslint/parser": ["@typescript-eslint/parser@8.66.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.66.0", "@typescript-eslint/types": "8.66.0", "@typescript-eslint/typescript-estree": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g=="],
 
-    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.66.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.66.0", "@typescript-eslint/types": "^8.66.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g=="],
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.67.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.67.0", "@typescript-eslint/types": "^8.67.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw=="],
 
     "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0" } }, "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g=="],
 
-    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.66.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g=="],
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.67.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg=="],
 
-    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "@typescript-eslint/typescript-estree": "8.66.0", "@typescript-eslint/utils": "8.66.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g=="],
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "@typescript-eslint/typescript-estree": "8.67.0", "@typescript-eslint/utils": "8.67.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q=="],
 
     "@typescript-eslint/types": ["@typescript-eslint/types@8.66.0", "", {}, "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ=="],
 
-    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.66.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.66.0", "@typescript-eslint/tsconfig-utils": "8.66.0", "@typescript-eslint/types": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg=="],
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.67.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.67.0", "@typescript-eslint/tsconfig-utils": "8.67.0", "@typescript-eslint/types": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw=="],
 
-    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.66.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.66.0", "@typescript-eslint/types": "8.66.0", "@typescript-eslint/typescript-estree": "8.66.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA=="],
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.67.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.67.0", "@typescript-eslint/types": "8.67.0", "@typescript-eslint/typescript-estree": "8.67.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg=="],
 
@@ -656,7 +656,7 @@
 
     "fontkitten": ["fontkitten@1.0.3", "", { "dependencies": { "tiny-inflate": "^1.0.3" } }, "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw=="],
 
-    "framer-motion": ["framer-motion@13.0.0", "", { "dependencies": { "motion-dom": "^13.0.0", "motion-utils": "^13.0.0", "tslib": "^2.4.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-nQGZXlsiigN48nzvE7AL1GLekql+etcphp8v+PQ0X04oxO20yVmV9rU9XQ25c136RdeIYoaWlKT9oAwvJza3mg=="],
+    "framer-motion": ["framer-motion@13.1.0", "", { "dependencies": { "motion-dom": "^13.0.0", "motion-utils": "^13.0.0", "tslib": "^2.4.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-QSZrF0Id3QGuHJ+OL+9PSY9pk86C8ERFalwAGSchzTm65+ZoGH/RM26lmEARLljcHj2lqhv0jZOOks+EI3COOw=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -782,7 +782,7 @@
 
     "minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
 
-    "motion": ["motion@13.0.0", "", { "dependencies": { "framer-motion": "^13.0.0", "tslib": "^2.4.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-RYZjEpgHUCKjBNqjmUQzW93VJWLvEZGTPdKRFSqOdOl07IIMvz+WrsZmD1XXAkoFLruW/8bO1L7UF+ViQTxtLg=="],
+    "motion": ["motion@13.1.0", "", { "dependencies": { "framer-motion": "^13.1.0", "tslib": "^2.4.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-qtvscq59uCPdWnNW4SdSkrxR+BS/QYsa923bx7ocA+4p+ZGNbbVQwkSnG4aukB81QWjtl3AxX36plxNyZLmHCA=="],
 
     "motion-dom": ["motion-dom@13.0.0", "", { "dependencies": { "motion-utils": "^13.0.0" } }, "sha512-Xk+SJas70uMAUIApg+m3lZDShxI3LBFHq7mFGbBKoRXc2PVPDyAKmzN64Bbzt4CZdP/CItTiJxWtn4TA0v53Ng=="],
 
@@ -970,11 +970,11 @@
 
     "typesafe-path": ["typesafe-path@0.2.2", "", {}, "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "typescript-auto-import-cache": ["typescript-auto-import-cache@0.3.6", "", { "dependencies": { "semver": "^7.3.8" } }, "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ=="],
 
-    "typescript-eslint": ["typescript-eslint@8.66.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.66.0", "@typescript-eslint/parser": "8.66.0", "@typescript-eslint/typescript-estree": "8.66.0", "@typescript-eslint/utils": "8.66.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw=="],
+    "typescript-eslint": ["typescript-eslint@8.67.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.67.0", "@typescript-eslint/parser": "8.67.0", "@typescript-eslint/typescript-estree": "8.67.0", "@typescript-eslint/utils": "8.67.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg=="],
 
     "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
 
@@ -1116,7 +1116,27 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@typescript-eslint/eslint-plugin/@typescript-eslint/parser": ["@typescript-eslint/parser@8.67.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.67.0", "@typescript-eslint/types": "8.67.0", "@typescript-eslint/typescript-estree": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w=="],
+
+    "@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0" } }, "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg=="],
+
+    "@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA=="],
+
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.6", "", {}, "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw=="],
+
+    "@typescript-eslint/parser/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.66.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.66.0", "@typescript-eslint/tsconfig-utils": "8.66.0", "@typescript-eslint/types": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg=="],
+
+    "@typescript-eslint/project-service/@typescript-eslint/types": ["@typescript-eslint/types@8.67.0", "", {}, "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww=="],
+
+    "@typescript-eslint/type-utils/@typescript-eslint/types": ["@typescript-eslint/types@8.67.0", "", {}, "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww=="],
+
+    "@typescript-eslint/typescript-estree/@typescript-eslint/types": ["@typescript-eslint/types@8.67.0", "", {}, "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww=="],
+
+    "@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA=="],
+
+    "@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0" } }, "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg=="],
+
+    "@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.67.0", "", {}, "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww=="],
 
     "@vscode/emmet-helper/jsonc-parser": ["jsonc-parser@2.3.1", "", {}, "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="],
 
@@ -1141,6 +1161,8 @@
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "sitemap/@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
+
+    "typescript-eslint/@typescript-eslint/parser": ["@typescript-eslint/parser@8.67.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.67.0", "@typescript-eslint/types": "8.67.0", "@typescript-eslint/typescript-estree": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w=="],
 
     "unstorage/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
@@ -1179,6 +1201,18 @@
     "@tailwindcss/node/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
 
     "@tailwindcss/node/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "@typescript-eslint/eslint-plugin/@typescript-eslint/parser/@typescript-eslint/types": ["@typescript-eslint/types@8.67.0", "", {}, "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww=="],
+
+    "@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@8.67.0", "", {}, "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww=="],
+
+    "@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys/@typescript-eslint/types": ["@typescript-eslint/types@8.67.0", "", {}, "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww=="],
+
+    "@typescript-eslint/parser/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.66.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.66.0", "@typescript-eslint/types": "^8.66.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g=="],
+
+    "@typescript-eslint/parser/@typescript-eslint/typescript-estree/@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.66.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g=="],
+
+    "@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA=="],
 
     "ajv-i18n/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -1289,6 +1323,12 @@
     "p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "sitemap/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "typescript-eslint/@typescript-eslint/parser/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0" } }, "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg=="],
+
+    "typescript-eslint/@typescript-eslint/parser/@typescript-eslint/types": ["@typescript-eslint/types@8.67.0", "", {}, "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww=="],
+
+    "typescript-eslint/@typescript-eslint/parser/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA=="],
 
     "unstorage/chokidar/readdirp": ["readdirp@5.1.1", "", {}, "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@tailwindcss/vite": "^4.3.3",
     "astro": "^7.2.0",
     "lenis": "^1.3.26",
-    "motion": "^13.0.0",
+    "motion": "^13.1.0",
     "tailwindcss": "^4.3.3"
   },
   "devDependencies": {
@@ -48,13 +48,13 @@
     "eslint": "^10.8.1",
     "eslint-plugin-astro": "^3.1.0",
     "globals": "^17.9.0",
-    "jiti": "^2.6.1",
+    "jiti": "^2.7.0",
     "prettier": "^3.9.6",
     "prettier-plugin-astro": "^0.14.1",
     "prettier-plugin-tailwindcss": "^0.8.1",
     "sharp": "^0.35.3",
-    "typescript": "^5.9.3",
-    "typescript-eslint": "^8.54.0",
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.67.0",
     "vitest": "^4.1.10",
     "wrangler": "^4.120.0"
   }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -21,4 +21,16 @@
    * deploy fails — see README.md § Deployment.
    */
   "routes": [{ "pattern": "siki.moe", "custom_domain": true }],
+  /*
+   * The site answers on siki.moe and nowhere else: `siki-moe.yousiki.workers.dev`
+   * would be a second indexable copy of the same pages.
+   *
+   * `preview_urls` defaults to whatever `workers_dev` is, so it has to be turned
+   * back on explicitly — the per-version URLs it controls are how `main` and every
+   * pull request get looked at before a release. They live at
+   * `<alias>-siki-moe.yousiki.workers.dev`; only `wrangler deploy` writes either
+   * of these settings, never `wrangler versions upload`.
+   */
+  "workers_dev": false,
+  "preview_urls": true,
 }


### PR DESCRIPTION
Moves deployment off Workers Builds and into Actions, and splits it in two: a push or pull request uploads a **preview version**, and only publishing a **GitHub Release** runs `wrangler deploy`.

The split is structural, not conditional. `wrangler versions upload` has no `--routes`, `--domain` or `--triggers` flag, so it cannot apply the `custom_domain` entry in `wrangler.jsonc` — wrangler prints that on every upload. A preview cannot touch siki.moe even if the workflow logic is wrong.

| Trigger | Workflow | Command | Result |
| --- | --- | --- | --- |
| Pull request | `ci.yml` | `wrangler versions upload` | `pr-<n>-siki-moe.yousiki.workers.dev` |
| Push to `main` | `ci.yml` | `wrangler versions upload` | `main-siki-moe.yousiki.workers.dev` |
| Release published | `release.yml` | `wrangler deploy` | `siki.moe` |

`verify.yml` is reusable and called by both, so a deploy is gated on the same checks a pull request gets, and `dist/` is built once and passed on as an artifact — the bytes verified are the bytes shipped. This closes the gap the old README admitted: nothing used to wait for CI.

`workers_dev` goes off (it was a second indexable copy of the same pages); `preview_urls` then has to be set explicitly, since it defaults to whatever `workers_dev` is.

### Verified out of band

siki.moe had been down — the apex had no DNS record, because the Pages→Worker migration in 4953e98 never landed on Cloudflare. A manual `wrangler deploy` restored it (version `cc443ac1`) and confirmed the pieces this PR depends on:

- `siki.moe` answers 200; `siki-moe.yousiki.workers.dev` answers Cloudflare `error code: 1042`, so `workers_dev: false` took effect
- `versions upload` works on an assets-only Worker, returning both the alias and versioned preview URLs (200 each)
- after that upload, `wrangler deployments list` still showed `cc443ac1` at 100% — the preview did not promote

### This PR is its own test

If `ci.yml` works, a comment with a `pr-<n>` preview link should appear below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Rebased onto #267, and now carries the dependency bumps

Rebased onto `1749817` — the eighteen source files the cleanup touched were byte-identical in the shared working tree, so the rebase was clean and `package.json` merged without conflict (script deletions and dependency ranges are separate hunks).

Four dependency bumps had been sitting uncommitted in the working tree, owned by neither PR: motion 13.0→13.1, jiti 2.6→2.7, typescript 5.9→**6.0**, typescript-eslint 8.54→8.67. Nobody had run the suite under them, and TypeScript is a major. They're now pinned with the lockfile after a green `bun run verify`: prettier, eslint, `astro check` 0 errors across 49 files, 40 tests, clean build.

`typescript` stays on 6.x deliberately, rather than lagging behind 7.0.2 — `typescript-eslint` declares `typescript >=4.8.4 <6.1.0` and `@astrojs/check` declares `^5.0.0 || ^6.0.0`, so TypeScript 7 would break both `bun run lint` and `bun run check`. `typescript-eslint` goes to 8.67.0 rather than the 8.66.0 that was in the tree, so the lockfile matches what a fresh install of the range resolves to.
