### PR TITLE
Prune dead code, stale comments, and tests that only restate the data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,16 @@
 # build output
 dist/
 .astro/
-.output/
 
 # dependencies
 node_modules/
 
 # tooling / caches
 .wrangler/
-.vercel/
-.netlify/
 *.tsbuildinfo
 
 # test artifacts
 test-results/
-playwright-report/
-blob-report/
 playwright/.cache/
 screenshots/
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,5 +4,4 @@ node_modules
 .wrangler
 bun.lock
 test-results
-playwright-report
 screenshots

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,11 +1,14 @@
-import { defineConfig, envField } from 'astro/config';
+import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
 
 import { SITE_URL } from './src/data/site';
 
-// Static output only: the whole site is prerendered at build time and served
-// from Cloudflare Pages' CDN, so there is no adapter and no server runtime.
+// Static output only: the whole site is prerendered at build time and served by
+// an assets-only Cloudflare Worker, so there is no adapter and no server runtime.
+//
+// No `prefetch`: every internal link on the site is a hash anchor, so Astro's
+// prefetch runtime would ship an extra module on every page and never fire.
 export default defineConfig({
   site: SITE_URL,
   output: 'static',
@@ -14,27 +17,12 @@ export default defineConfig({
     format: 'directory',
     inlineStylesheets: 'auto',
   },
-  prefetch: {
-    prefetchAll: true,
-    defaultStrategy: 'hover',
-  },
   integrations: [
     sitemap({
       // `/og` exists only as a screenshot source for the social card.
       filter: (page) => !page.includes('/og'),
     }),
   ],
-  env: {
-    schema: {
-      PUBLIC_SITE_ENV: envField.enum({
-        context: 'client',
-        access: 'public',
-        values: ['production', 'preview', 'development'],
-        default: 'development',
-        optional: true,
-      }),
-    },
-  },
   vite: {
     plugins: [tailwindcss()],
     build: {

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -11,7 +11,6 @@ export default defineConfig([
     'node_modules/**',
     '.wrangler/**',
     'test-results/**',
-    'playwright-report/**',
     'screenshots/**',
   ]),
   js.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "packageManager": "bun@1.3.14",
   "scripts": {
     "dev": "astro dev",
-    "start": "astro dev",
     "build": "bun run cv && astro build",
     "preview": "astro preview",
     "serve": "bun run scripts/serve.ts",
@@ -20,7 +19,6 @@
     "fonts:cjk": "bun run scripts/fetch-cjk-font.ts",
     "sync": "astro sync",
     "check": "astro check",
-    "typecheck": "astro check",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,11 +6,12 @@ const LOCAL_URL = `http://localhost:${PORT}`;
 /**
  * Playwright is kept for screenshots only — `bun run shots` captures the pages
  * for design review, and `scripts/generate-assets.ts` renders the social card.
- * Nothing here asserts anything; there is no behavioural suite to run.
+ * Nothing here asserts anything, there is no behavioural suite to run, and CI
+ * never invokes it — so there are no retry, trace or reporter knobs to set.
  *
  * Point it at a deployment instead of the local build:
  *
- *   PLAYWRIGHT_BASE_URL=https://siki-moe-preview.pages.dev bun run shots
+ *   PLAYWRIGHT_BASE_URL=https://siki.moe bun run shots
  *
  * The local static server is skipped when an external target is given.
  */
@@ -19,20 +20,11 @@ const BASE_URL = EXTERNAL_URL ?? LOCAL_URL;
 
 export default defineConfig({
   testDir: './tests/visual',
-  outputDir: './test-results',
   fullyParallel: true,
-  forbidOnly: !!process.env['CI'],
-  retries: process.env['CI'] ? 2 : 0,
-  // Left unset off CI so Playwright picks a worker count from the machine.
-  ...(process.env['CI'] ? { workers: 2 } : {}),
-  reporter: process.env['CI'] ? [['github'], ['html', { open: 'never' }]] : [['list']],
-  timeout: 30_000,
-  expect: { timeout: 7_000 },
+  reporter: [['list']],
 
   use: {
     baseURL: BASE_URL,
-    trace: 'on-first-retry',
-    screenshot: 'only-on-failure',
   },
 
   projects: [
@@ -51,7 +43,7 @@ export default defineConfig({
         webServer: {
           command: `bun run scripts/serve.ts ${PORT}`,
           url: LOCAL_URL,
-          reuseExistingServer: !process.env['CI'],
+          reuseExistingServer: true,
           timeout: 120_000,
           stdout: 'ignore' as const,
           stderr: 'pipe' as const,

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "Siqi Yang — siki.moe",
   "short_name": "Siqi Yang",
-  "description": "Ph.D. candidate at Peking University working on neuromorphic imaging, inverse rendering, and video world models.",
+  "description": "Ph.D. candidate at Peking University working on neuromorphic imaging, video generation, and world models.",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#08080a",

--- a/src/components/Icon.astro
+++ b/src/components/Icon.astro
@@ -1,7 +1,7 @@
 ---
 /**
- * Hand-picked inline SVGs. A whole icon library would outweigh the eight glyphs
- * this site actually uses.
+ * Hand-picked inline SVGs. A whole icon library would outweigh the handful of
+ * glyphs this site actually uses.
  */
 export type IconName =
   | 'github'

--- a/src/components/SectionHeading.astro
+++ b/src/components/SectionHeading.astro
@@ -3,10 +3,9 @@ interface Props {
   index: string;
   title: string;
   lead?: string;
-  id?: string;
 }
 
-const { index, title, lead, id } = Astro.props;
+const { index, title, lead } = Astro.props;
 ---
 
 <header class="mb-12 md:mb-16">
@@ -16,7 +15,6 @@ const { index, title, lead, id } = Astro.props;
   </div>
 
   <h2
-    id={id}
     class="font-display mt-5 text-4xl leading-[1.05] tracking-tight sm:text-5xl md:text-6xl"
     data-reveal
     style="--reveal-delay:80ms"

--- a/src/components/SplitText.astro
+++ b/src/components/SplitText.astro
@@ -7,14 +7,13 @@ interface Props {
   text: string;
   /** Milliseconds added before this block's first character animates. */
   baseDelay?: number;
-  class?: string;
 }
 
-const { text, baseDelay = 0, class: className } = Astro.props;
+const { text, baseDelay = 0 } = Astro.props;
 const characters = [...text];
 ---
 
-<span class={className} style={`--char-base:${baseDelay}ms`} aria-label={text} data-split-text>
+<span style={`--char-base:${baseDelay}ms`} aria-label={text}>
   {
     characters.map((char, index) =>
       char === ' ' ? (

--- a/src/data/profile.ts
+++ b/src/data/profile.ts
@@ -511,17 +511,3 @@ export const profile: Profile = {
 export const publicationsByYear: readonly Publication[] = [...profile.publications].sort(
   (a, b) => b.year - a.year,
 );
-
-/** The subset rendered before the reader asks for the full list. */
-export const selectedPublications: readonly Publication[] = publicationsByYear.filter(
-  (p) => p.selected,
-);
-
-/** Distinct venues, for the stat strip. */
-export const publicationVenues: readonly string[] = [
-  ...new Set(
-    profile.publications
-      .map((p) => p.venue)
-      .filter((v) => !v.includes('arXiv') && !v.includes('Chapter')),
-  ),
-];

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -12,10 +12,5 @@ export const SITE_DESCRIPTION =
 
 export const SITE_LOCALE = 'en';
 
-/** OpenGraph image, generated at build time into `/og.svg`. */
+/** OpenGraph card, committed to `public/` by `bun run assets`. */
 export const SITE_OG_IMAGE = '/og.png';
-
-export const SITE_THEME_COLOR = {
-  light: '#f6f4ef',
-  dark: '#08080a',
-} as const;

--- a/src/scripts/env.ts
+++ b/src/scripts/env.ts
@@ -9,8 +9,6 @@ export const hasFinePointer = (): boolean =>
 export const clamp = (value: number, min: number, max: number): number =>
   value < min ? min : value > max ? max : value;
 
-export const lerp = (from: number, to: number, t: number): number => from + (to - from) * t;
-
 /** `document.querySelectorAll` with a concrete element type and a real array. */
 export const queryAll = <T extends Element = HTMLElement>(
   selector: string,
@@ -19,7 +17,8 @@ export const queryAll = <T extends Element = HTMLElement>(
 
 /**
  * Runs `fn` once the document is interactive. Astro injects module scripts with
- * `defer`, but view transitions can re-run them against a live document.
+ * `defer`, so the document is usually already parsed — the branch is for the
+ * case where it is not.
  */
 export const onReady = (fn: () => void): void => {
   if (document.readyState === 'loading') {

--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -33,6 +33,4 @@ onReady(() => {
 
   const canvas = document.querySelector<HTMLCanvasElement>('[data-spike-field]');
   if (canvas) initSpikeField(canvas);
-
-  document.documentElement.dataset['jsReady'] = '';
 });

--- a/src/scripts/scroll.ts
+++ b/src/scripts/scroll.ts
@@ -3,8 +3,8 @@ import Lenis from 'lenis';
 import { prefersReducedMotion, queryAll } from './env';
 
 /** Momentum scrolling, unless the visitor asked for reduced motion. */
-export const initSmoothScroll = (): Lenis | null => {
-  if (prefersReducedMotion()) return null;
+export const initSmoothScroll = (): void => {
+  if (prefersReducedMotion()) return;
 
   const lenis = new Lenis({
     duration: 1.05,
@@ -30,8 +30,6 @@ export const initSmoothScroll = (): Lenis | null => {
       history.replaceState(null, '', id);
     });
   }
-
-  return lenis;
 };
 
 /**

--- a/src/scripts/spike-field.ts
+++ b/src/scripts/spike-field.ts
@@ -108,13 +108,9 @@ const createSources = (): Source[] =>
     { cx: 0.52, cy: 0.82, rx: 0.26, ry: 0.1, speed: 0.031, phase: 4.4, radius: 0.36, power: 0.6 },
   ].map((s) => ({ ...s, x: s.cx, y: s.cy }));
 
-export interface SpikeFieldHandle {
-  destroy(): void;
-}
-
-export const initSpikeField = (canvas: HTMLCanvasElement): SpikeFieldHandle | null => {
+export const initSpikeField = (canvas: HTMLCanvasElement): void => {
   const context = canvas.getContext('2d', { alpha: true });
-  if (!context) return null;
+  if (!context) return;
 
   const ctx = context;
   const sources = createSources();
@@ -332,16 +328,4 @@ export const initSpikeField = (canvas: HTMLCanvasElement): SpikeFieldHandle | nu
     intersectionObserver.observe(canvas);
     start();
   }
-
-  return {
-    destroy(): void {
-      stop();
-      resizeObserver.disconnect();
-      intersectionObserver.disconnect();
-      canvas.removeEventListener('pointermove', onPointerMove);
-      canvas.removeEventListener('pointerleave', onPointerLeave);
-      document.removeEventListener('visibilitychange', onVisibility);
-      window.removeEventListener('themechange', onThemeChange);
-    },
-  };
 };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -38,9 +38,6 @@
 
   --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
   --ease-out-quint: cubic-bezier(0.22, 1, 0.36, 1);
-  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
-
-  --breakpoint-xs: 26rem;
 }
 
 /* ── Palette ─────────────────────────────────────────────────────────────── */
@@ -203,7 +200,7 @@
    adding `data-revealed`. The no-JS fallback in BaseHead removes the hiding. */
 [data-reveal] {
   opacity: 0;
-  transform: translate3d(0, var(--reveal-y, 1.75rem), 0);
+  transform: translate3d(0, 1.75rem, 0);
   transition:
     opacity 0.9s var(--ease-out-expo) var(--reveal-delay, 0ms),
     transform 0.9s var(--ease-out-expo) var(--reveal-delay, 0ms),

--- a/tests/unit/profile.test.ts
+++ b/tests/unit/profile.test.ts
@@ -3,13 +3,9 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { profile, publicationsByYear, selectedPublications, SELF } from '../../src/data/profile';
+import { profile, publicationsByYear, SELF } from '../../src/data/profile';
 
 describe('profile identity', () => {
-  it('uses the same display name the publication list marks as the author', () => {
-    expect(profile.name).toBe(SELF);
-  });
-
   it('exposes a mailto social that matches the canonical email', () => {
     const mail = profile.socials.find((s) => s.icon === 'mail');
     expect(mail?.href).toBe(`mailto:${profile.email}`);
@@ -55,25 +51,16 @@ describe('links', () => {
 });
 
 describe('cv editions', () => {
-  it('offers English, Chinese and the bilingual edition, English first', () => {
-    expect(profile.cv.map((edition) => edition.id)).toEqual(['en', 'zh', 'en-zh']);
-  });
-
-  it('names every file after the edition it holds', () => {
+  it('names every file after the edition it holds, on this site', () => {
     // The id is what the menu, the release asset, the vendored file and the
     // Typst entry point all agree on; a drifting href is the failure to catch.
+    // The leading `/` is load-bearing too: the resume repository is private, so
+    // a GitHub release URL 404s for every visitor — that regression is what put
+    // a dead CV link on the site.
     for (const edition of profile.cv) {
       expect(edition.href, edition.label).toMatch(
         new RegExp(`^/cv/[a-z0-9-]+-${edition.id}\\.pdf$`),
       );
-    }
-  });
-
-  it('is served by this site, not by a third party', () => {
-    // The resume repository is private, so a GitHub release URL 404s for every
-    // visitor. This is the regression that put a dead CV link on the site.
-    for (const edition of profile.cv) {
-      expect(edition.href, edition.label).toMatch(/^\//);
     }
   });
 
@@ -106,9 +93,13 @@ describe('publications', () => {
     expect(new Set(titles).size).toBe(titles.length);
   });
 
-  it('surface a non-empty selection that is a strict subset', () => {
-    expect(selectedPublications.length).toBeGreaterThan(0);
-    expect(selectedPublications.length).toBeLessThan(publicationsByYear.length);
+  it('mark some but not all of themselves as selected', () => {
+    // The disclosure only makes sense between the two extremes: nothing
+    // selected renders an empty list, everything selected renders a toggle
+    // that reveals nothing.
+    const selected = publicationsByYear.filter((p) => p.selected);
+    expect(selected.length).toBeGreaterThan(0);
+    expect(selected.length).toBeLessThan(publicationsByYear.length);
   });
 
   it('note equal contribution whenever an author carries an asterisk', () => {

--- a/tests/unit/text.test.ts
+++ b/tests/unit/text.test.ts
@@ -8,12 +8,6 @@ describe('escapeHtml', () => {
       '&lt;img src=x onerror=&quot;alert(&#39;1&#39;)&quot;&gt;&amp;',
     );
   });
-
-  it('leaves ordinary prose untouched', () => {
-    expect(escapeHtml('Spike cameras fire asynchronously.')).toBe(
-      'Spike cameras fire asynchronously.',
-    );
-  });
 });
 
 describe('emphasise', () => {
@@ -73,10 +67,7 @@ describe('authorSegments', () => {
     const segments = authorSegments(['Siqi Yang*', 'Chu Zhou*'], 'Siqi Yang');
     expect(segments[0]?.isSelf).toBe(true);
     expect(segments[1]?.isSelf).toBe(false);
-  });
-
-  it('preserves the original order and spelling', () => {
-    const authors = ['A', 'B', 'C'];
-    expect(authorSegments(authors, 'Siqi Yang').map((s) => s.name)).toEqual(authors);
+    // The asterisk stays in the rendered name — it is what the note refers to.
+    expect(segments[0]?.name).toBe('Siqi Yang*');
   });
 });


### PR DESCRIPTION
An audit of every tracked file for three things: code nothing reaches, comments that no longer describe what they sit next to, and assertions with no invariant behind them. 19 files, +39/−132.

`bun run verify` is green on this branch from a clean `bun install --frozen-lockfile`: format, lint, `astro check` (0 errors / 0 warnings across 49 files), 40 tests, build.

## Removed because nothing referenced it

| Symbol | Note |
| --- | --- |
| `lerp` (`src/scripts/env.ts`) | zero call sites |
| `SITE_THEME_COLOR` (`src/data/site.ts`) | zero references; `BaseHead` carries the literal |
| `publicationVenues` (`src/data/profile.ts`) | comment claimed "for the stat strip" — there is no stat strip |
| `selectedPublications` (`src/data/profile.ts`) | the page renders the full list and branches on `publication.selected` per row, so the only reader was its own test |
| `SpikeFieldHandle` / `destroy()` | both call sites discard the return value, so the teardown could never run |
| `initSmoothScroll`'s return value | a Lenis instance nobody holds |
| `data-js-ready`, `data-split-text`, `SplitText`'s `class` prop, `SectionHeading`'s `id` prop | no selector or caller |
| `--ease-spring`, `--breakpoint-xs` | no `xs:` utility exists; nothing reads the easing |
| `--reveal-y` | never set anywhere — folded into the literal it always resolved to |
| `typecheck`, `start` scripts | duplicates of `check` and `dev` |

## The prefetch removal is the one behaviour change

Every internal link on this site is a hash anchor, so Astro's prefetch runtime shipped an extra module on every page and prefetched nothing — the built HTML contained zero `rel="prefetch"` links. Measured both ways:

- before: `index.html` loads 2 modules (29.0 kB gz + 1.1 kB gz)
- after: 1 module (29.0 kB gz)

Which is what the README's "one ~30 kB gzipped module" already claimed, so no doc change was needed there. The dead `PUBLIC_SITE_ENV` schema entry goes with it — nothing read it.

## Comments that had drifted

- `astro.config.ts` still described serving from Cloudflare Pages' CDN
- `site.ts` pointed at an `/og.svg` "generated at build time" — it is `/og.png`, written by `bun run assets`
- `Icon.astro` counted eight glyphs where the sprite has eleven (all eleven are used)
- `onReady` explained itself in terms of view transitions this site does not use
- `playwright.config.ts` gave a dead `pages.dev` URL as its example
- `public/site.webmanifest`'s description had drifted from `SITE_DESCRIPTION`

## Playwright and the ignore files

Playwright's retry, worker, trace, screenshot and reporter branches were all conditioned on `CI`, which never invokes it — and there is nothing to retry in a suite that asserts nothing. What remains is what a `bun run shots` run actually uses. The ignore files lose entries for tools this project does not use (`.vercel/`, `.netlify/`, `.output/`, `blob-report/`, `playwright-report/`).

## Tests

Six removed for restating the data rather than constraining it: a CV id list compared against the same literal, `profile.name` compared against `SELF` two constants apart, an `authorSegments` identity map, an `escapeHtml` no-op, and a leading-slash assertion already implied by the href regex beside it.

Two strengthened: the selected-publications bound is rewritten against `publicationsByYear.filter(...)` and now says why *both* ends matter, and the equal-contribution case also pins that the asterisk survives into the rendered name.

Everything that guards a real invariant stays — the CJK subset checks, the CSP checks, and the ordering/author/timezone assertions. 40 tests, all load-bearing.

## Scope

Deliberately excludes work in flight from another session: `.github/workflows/*`, `wrangler.jsonc`, and README § Deployment are untouched. The `package.json` diff here is the two script deletions only — the dependency bumps sitting in the working tree (motion, jiti, typescript, typescript-eslint) and their `bun.lock` are somebody else's change and are not in this branch.
