### PR TITLE
Slow Dependabot to monthly and pin TypeScript below 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,12 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
-      day: monday
-    open-pull-requests-limit: 5
+      interval: monthly
+    open-pull-requests-limit: 3
+    # TypeScript 7 drops the JS compiler API that eslint and `astro check` need.
+    ignore:
+      - dependency-name: typescript
+        versions: ['>= 7']
     groups:
       astro:
         patterns: ['astro', '@astrojs/*']


### PR DESCRIPTION
## What

Three changes to the npm entry in `.github/dependabot.yml`:

1. `interval: weekly` → `monthly` (and drop `day: monday`, which only applies to weekly). The `github-actions` entry was already monthly, so both ecosystems now batch once a month.
2. `open-pull-requests-limit: 5` → `3`.
3. Ignore `typescript >= 7`.

## Why pin TypeScript

TypeScript 7 removes the JS compiler API that eslint's type-aware rules and `astro check` rely on, so #265 could not land. Closing that PR alone isn't enough — Dependabot reopens the bump on the next run. The `ignore` rule is what actually holds the line at 6.x.

## Notes

- The `github-actions` entry still has no `open-pull-requests-limit`, so it uses the default of 5. Say the word if that should be 3 too.
- Related cleanup done separately: closed #261, #148, #140 (all patching workflow files that no longer exist) and #265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)