### PR TITLE
Cut the entry module 7.5×, hash the inline scripts, admit the beacon

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,25 @@ reduced motion.
 | Tests     | Vitest (units). Playwright is kept for screenshots only — there is no browser suite                                                         |
 | Hosting   | Cloudflare Workers, assets-only — the custom domain lives in `wrangler.jsonc`                                                               |
 
-Total shipped JavaScript is one ~30 kB gzipped module; the page renders and reads
-completely without it.
+The page renders and reads completely without JavaScript. What it does ship is
+split along the guards the code already had, so nobody downloads an animation
+library that could not have run for them:
+
+| Visitor                          | Chunks requested     | gzipped     |
+| -------------------------------- | -------------------- | ----------- |
+| `prefers-reduced-motion: reduce` | entry + spike canvas | **5.9 kB**  |
+| Touch device                     | + Lenis              | **11.3 kB** |
+| Pointer-fine desktop             | + Motion             | 32.5 kB     |
+
+The entry module is 3.9 kB; Motion (21.2 kB) and Lenis (5.4 kB) are `import()`ed
+_after_ `hasFinePointer()` and `prefersReducedMotion()` have decided whether they
+can be used at all. Previously both were static imports, which put all 29.0 kB of
+them in the entry module — on the critical path, for every visitor, including the
+ones whose device made them unreachable.
+
+A desktop visitor now transfers slightly _more_ in total (32.5 kB against 31.0 kB),
+because three chunks compress a little worse than one. That is the trade: the
+blocking path shrinks 7.5×, and phones drop by two thirds.
 
 ## Getting started
 
@@ -165,6 +182,55 @@ whatever `workers_dev` is. Only `wrangler deploy` writes either setting.
 `public/_headers` sets a strict Content-Security-Policy and immutable caching for
 fingerprinted assets; Workers parses it rather than serving it, and applies it at
 the edge.
+
+Its `script-src` names the two inline scripts — the theme bootstrap and the
+JSON-LD block — by SHA-256 rather than allowing `'unsafe-inline'`. Those hashes
+cannot live in the template, because they change whenever `BaseHead.astro` or
+`src/data/profile.ts` does, so `public/_headers` carries a `{{SCRIPT_HASHES}}`
+placeholder and [`scripts/build-headers.ts`](scripts/build-headers.ts) substitutes
+the real values into `dist/_headers` at the end of every build, reading them out
+of the HTML that was actually emitted. It exits non-zero rather than write a
+policy with nothing in that slot.
+
+This is worth knowing because of how the failure looks: a CSP carrying any hash
+makes browsers ignore `'unsafe-inline'` altogether, so a stale hash does not
+degrade to the old permissive policy — it blocks the theme bootstrap, and the site
+paints the wrong palette for one frame before correcting itself. Nothing about the
+build fails. `bun run serve` therefore applies `dist/_headers` as Cloudflare would,
+which makes that class of mistake visible in a local browser console instead of
+only in production. Two zone settings can reintroduce it from outside the
+repository: **Rocket Loader** and any HTML-minifying feature rewrite inline
+scripts after the hashes were computed, so both need to stay off.
+
+## Analytics
+
+Page views and Core Web Vitals come from [Cloudflare Web
+Analytics](https://developers.cloudflare.com/web-analytics/), enabled on the
+`siki.moe` zone with **automatic injection** — the default when you add a proxied
+hostname under Web Analytics in the dashboard. It is the one piece of this site's
+configuration that is not in this repository, which is a real cost; it buys three
+things that the manual JS snippet does not:
+
+- The beacon reports to `siki.moe/cdn-cgi/rum`, first-party, so `connect-src` in
+  the CSP stays `'self'`. A manual snippet reports to `cloudflareinsights.com` and
+  would need that origin allowed.
+- Cloudflare adds an `integrity` attribute to the injected tag. The docs are
+  explicit that manual embeds cannot be given SRI, because the beacon is not
+  version-pinned.
+- Preview deploys land on `*.workers.dev`, which is not on the zone and so is
+  never injected. Because `dist/` is built once in `verify.yml` and handed to both
+  the preview and the production deploy, a token committed to the repository would
+  necessarily report from previews too.
+
+No cookies, no page-view sampling, and query strings are not logged. The only
+trace in this repository is `static.cloudflareinsights.com/beacon.min.js` in the
+`script-src` above.
+
+Two things silently break it. An HTML response carrying `Cache-Control: public,
+no-transform` stops the injection outright — so if HTML caching is ever added to
+`public/_headers`, leave `no-transform` out of it. And the dashboard's **Manage
+site** must stay on automatic rather than "Enable with JS Snippet installation";
+the modes are alternatives, and running both would double-count.
 
 ## Licence
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siki-moe",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": true,
   "type": "module",
   "description": "Personal site of Siqi Yang (YouSiki) — siki.moe",
@@ -11,7 +11,7 @@
   "packageManager": "bun@1.3.14",
   "scripts": {
     "dev": "astro dev",
-    "build": "bun run cv && astro build",
+    "build": "bun run cv && astro build && bun run scripts/build-headers.ts",
     "preview": "astro preview",
     "serve": "bun run scripts/serve.ts",
     "cv": "bun run scripts/sync-cv.ts",

--- a/public/_headers
+++ b/public/_headers
@@ -2,11 +2,39 @@
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
-  Permissions-Policy: geolocation=(), microphone=(), camera=(), interest-cohort=()
+  Permissions-Policy: geolocation=(), microphone=(), camera=()
+  # A year, and this hostname only. Both omissions are deliberate:
+  #
+  # `includeSubDomains` would bind every siki.moe subdomain to HTTPS for the full
+  # max-age, which would make an HTTP-only one — an internal service, a throwaway
+  # demo — unreachable until the year elapsed. Cloudflare's dashboard puts that
+  # behind an "I understand" dialog; reaching it through this file would skip the
+  # dialog without skipping the consequence.
+  #
+  # `preload` submits the domain to a list compiled into browser binaries, which
+  # takes months to get back off.
+  Strict-Transport-Security: max-age=31536000
+  # Nothing here opens a window it needs to talk to, so severing the connection
+  # to any window that opens this one costs nothing.
+  Cross-Origin-Opener-Policy: same-origin
   # `font-src` needs data: — the CJK subset is small enough that Vite inlines it
   # into the stylesheet as a data URI, which is deliberate so the Chinese name
   # paints with the rest of the page. See src/styles/fonts/.
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self'; object-src 'none'; upgrade-insecure-requests
+  #
+  # `script-src` names its inline scripts by hash instead of allowing
+  # 'unsafe-inline'. {{SCRIPT_HASHES}} is substituted at the end of the build by
+  # scripts/build-headers.ts, which reads the hashes out of the emitted HTML —
+  # note that once a hash is present browsers ignore 'unsafe-inline' entirely,
+  # so a stale hash blocks the script rather than degrading to the old policy.
+  #
+  # static.cloudflareinsights.com is Cloudflare Web Analytics, injected into the
+  # HTML by the zone rather than by this repository (see README.md § Analytics).
+  # Its beacon reports to siki.moe/cdn-cgi/rum, so `connect-src` stays 'self'.
+  #
+  # `style-src` keeps 'unsafe-inline': Astro's `inlineStylesheets: 'auto'` puts
+  # small stylesheets straight into the document, and component `<style>` blocks
+  # are inline by nature.
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' {{SCRIPT_HASHES}} https://static.cloudflareinsights.com/beacon.min.js; connect-src 'self'; object-src 'none'; upgrade-insecure-requests
 
 # Fingerprinted build output — safe to keep forever.
 /_astro/*

--- a/scripts/build-headers.ts
+++ b/scripts/build-headers.ts
@@ -1,0 +1,81 @@
+/**
+ * Substitutes the inline-script hashes into `dist/_headers` after a build.
+ *
+ * `public/_headers` cannot hold the hashes itself: they change whenever the
+ * theme bootstrap in `BaseHead.astro` or the JSON-LD derived from
+ * `src/data/profile.ts` changes, and a hash that has fallen a character behind
+ * fails in the worst available way — the browser blocks the very script the CSP
+ * was written to admit, and the site paints the wrong palette before correcting
+ * itself. So the template carries a placeholder and this fills it in from the
+ * HTML that was actually emitted.
+ *
+ * `bun run build` runs this last, after Astro has copied `public/_headers` into
+ * `dist/`. Cloudflare reads the copy in `dist/`; the template is never served.
+ */
+import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+import { collectScriptHashes, SCRIPT_HASH_PLACEHOLDER } from './lib/csp';
+
+const DIST = join(process.cwd(), 'dist');
+const HEADERS = join(DIST, '_headers');
+
+function stop(reason: string): never {
+  console.error(`headers: ${reason}`);
+  process.exit(1);
+}
+
+/** Every `.html` file under `dist/`, at any depth. */
+const htmlFiles = (dir: string): string[] => {
+  const found: string[] = [];
+
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) found.push(...htmlFiles(path));
+    else if (entry.endsWith('.html')) found.push(path);
+  }
+
+  return found;
+};
+
+if (!statSync(DIST, { throwIfNoEntry: false })?.isDirectory()) {
+  stop(`no build at ${DIST} — run \`astro build\` first`);
+}
+
+if (!statSync(HEADERS, { throwIfNoEntry: false })?.isFile()) {
+  stop('dist/_headers is missing — public/_headers should have been copied into the build');
+}
+
+const template = readFileSync(HEADERS, 'utf8');
+
+if (!template.includes(SCRIPT_HASH_PLACEHOLDER)) {
+  stop(
+    `public/_headers has no ${SCRIPT_HASH_PLACEHOLDER} to substitute. ` +
+      'Without it the deployed CSP would name no inline script and block the theme bootstrap.',
+  );
+}
+
+const pages = htmlFiles(DIST);
+if (pages.length === 0) stop('the build emitted no HTML');
+
+const hashes = collectScriptHashes(pages.map((page) => readFileSync(page, 'utf8')));
+
+/*
+ * Zero hashes means either the extraction broke or the inline scripts went away.
+ * The first is a bug and the second is a deliberate change to `BaseHead.astro`;
+ * either way, silently writing a CSP with an empty `script-src` slot is worse
+ * than refusing to write one.
+ */
+if (hashes.length === 0) {
+  stop(
+    `found no inline <script> in ${pages.length} page(s). ` +
+      'If BaseHead.astro genuinely stopped emitting one, drop the placeholder from public/_headers.',
+  );
+}
+
+writeFileSync(HEADERS, template.replaceAll(SCRIPT_HASH_PLACEHOLDER, hashes.join(' ')));
+
+console.warn(
+  `headers: hashed ${hashes.length} inline script(s) from ${pages.length} page(s) into ` +
+    `${relative(process.cwd(), HEADERS)}`,
+);

--- a/scripts/lib/csp.ts
+++ b/scripts/lib/csp.ts
@@ -1,0 +1,75 @@
+/**
+ * Hashes the inline `<script>` blocks in the built HTML, so the
+ * Content-Security-Policy in `public/_headers` can name them one by one instead
+ * of opening `script-src` up to `'unsafe-inline'`.
+ *
+ * Shared by `scripts/build-headers.ts`, which substitutes the hashes into
+ * `dist/_headers`, and by `tests/unit/csp.test.ts`, which pins the extraction
+ * against hand-written HTML. Both need the same answer, so neither owns it.
+ *
+ * A hash has to match the script body byte for byte, so nothing here trims,
+ * normalises newlines, or reformats: whatever sits between the tags is what
+ * gets hashed.
+ */
+
+import { createHash } from 'node:crypto';
+
+/** The token `public/_headers` carries where the hashes belong. */
+export const SCRIPT_HASH_PLACEHOLDER = '{{SCRIPT_HASHES}}';
+
+/*
+ * Attribute values in this site's markup never contain `>`, so a regex is enough
+ * and saves pulling in an HTML parser. The body match is lazy, so it stops at
+ * the first closing tag rather than swallowing everything up to the last one.
+ */
+const SCRIPT_ELEMENT = /<script([^>]*)>([\s\S]*?)<\/script\s*>/gi;
+const HAS_SRC_ATTRIBUTE = /\ssrc\s*=/i;
+
+/**
+ * Every inline script body in `html`, in document order, including duplicates.
+ *
+ * Elements carrying `src` are left out: they are external, and `script-src`
+ * admits them by origin rather than by hash. `type` is ignored on purpose —
+ * a `application/ld+json` block never executes, but browsers still hold it to
+ * `script-src`, so it needs a hash exactly like an executable one.
+ */
+export const extractInlineScripts = (html: string): string[] => {
+  const bodies: string[] = [];
+
+  for (const match of html.matchAll(SCRIPT_ELEMENT)) {
+    const [, attributes = '', body = ''] = match;
+    if (HAS_SRC_ATTRIBUTE.test(attributes)) continue;
+    if (body === '') continue;
+    bodies.push(body);
+  }
+
+  return bodies;
+};
+
+/**
+ * One script body as the source expression CSP expects.
+ *
+ * The surrounding single quotes are not decoration — a hash-source is only a
+ * hash-source when quoted. Left bare, `sha256-abc…` is parsed as a *host*
+ * instead: browsers quietly accept the ones that happen to look like a hostname
+ * and reject the ones containing base64's `+` as an invalid source, so roughly
+ * half the mistake is silent and the inline script is blocked either way.
+ */
+export const hashInlineScript = (body: string): string =>
+  `'sha256-${createHash('sha256').update(body, 'utf8').digest('base64')}'`;
+
+/**
+ * The deduplicated hashes for a set of HTML documents, sorted so that the same
+ * build always produces the same `_headers` line.
+ */
+export const collectScriptHashes = (documents: string[]): string[] => {
+  const hashes = new Set<string>();
+
+  for (const html of documents) {
+    for (const body of extractInlineScripts(html)) {
+      hashes.add(hashInlineScript(body));
+    }
+  }
+
+  return [...hashes].sort();
+};

--- a/scripts/serve.ts
+++ b/scripts/serve.ts
@@ -4,9 +4,17 @@
  *
  * `astro preview` daemonises itself, which a process supervisor such as
  * Playwright's `webServer` cannot manage — this stays in the foreground.
+ *
+ * It also applies `dist/_headers`. Cloudflare is what reads that file in
+ * production, so without this every mistake in it — a Content-Security-Policy
+ * that blocks the site's own theme bootstrap, say — would stay invisible until
+ * after a deploy. See scripts/build-headers.ts, which generates the CSP hashes
+ * that this is the only local way to check.
  */
-import { existsSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { join, normalize } from 'node:path';
+
+import { SCRIPT_HASH_PLACEHOLDER } from './lib/csp';
 
 const ROOT = join(process.cwd(), 'dist');
 const PORT = Number(process.env['PORT'] ?? process.argv[2] ?? 4321);
@@ -15,6 +23,86 @@ if (!existsSync(ROOT)) {
   console.error(`No build found at ${ROOT}. Run \`bun run build\` first.`);
   process.exit(1);
 }
+
+/** One `_headers` block: the paths it matches and the headers it contributes. */
+interface HeaderRule {
+  readonly matches: RegExp;
+  readonly headers: readonly (readonly [string, string])[];
+}
+
+/** `/_astro/*` → a regex in which `*` is the only surviving metacharacter. */
+const patternToRegExp = (pattern: string): RegExp =>
+  new RegExp(
+    `^${pattern
+      .split('*')
+      .map((literal) => literal.replace(/[.+?^${}()|[\]\\]/g, '\\$&'))
+      .join('.*')}$`,
+  );
+
+/**
+ * Parses the subset of Cloudflare's `_headers` syntax this site uses: a path
+ * pattern at column zero, its headers indented beneath it, `#` for comments.
+ * `*` is the only wildcard in play; `:placeholder` segments are left out because
+ * nothing here uses them.
+ */
+const parseHeaderRules = (source: string): HeaderRule[] => {
+  const rules: { pattern: string; headers: [string, string][] }[] = [];
+
+  for (const line of source.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed === '' || trimmed.startsWith('#')) continue;
+
+    // Column zero starts a new block; anything indented belongs to the last one.
+    if (!/^\s/.test(line)) {
+      rules.push({ pattern: trimmed, headers: [] });
+      continue;
+    }
+
+    const separator = trimmed.indexOf(':');
+    const current = rules.at(-1);
+    if (separator === -1 || !current) continue;
+    current.headers.push([trimmed.slice(0, separator).trim(), trimmed.slice(separator + 1).trim()]);
+  }
+
+  return rules.map(({ pattern, headers }) => ({ headers, matches: patternToRegExp(pattern) }));
+};
+
+const headerFile = join(ROOT, '_headers');
+const rules = existsSync(headerFile) ? parseHeaderRules(readFileSync(headerFile, 'utf8')) : [];
+
+if (rules.length === 0) {
+  console.warn(`No _headers found in ${ROOT} — serving without the production headers.`);
+} else if (
+  rules.some((rule) => rule.headers.some(([, value]) => value.includes(SCRIPT_HASH_PLACEHOLDER)))
+) {
+  console.warn(
+    `dist/_headers still contains ${SCRIPT_HASH_PLACEHOLDER} — run \`bun run build\` rather ` +
+      'than `astro build`, so scripts/build-headers.ts substitutes the inline-script hashes.',
+  );
+}
+
+/**
+ * The headers production would send for `pathname`. Rules apply in file order
+ * and a later one wins, which is how Cloudflare layers overlapping blocks.
+ */
+const headersFor = (pathname: string): Headers => {
+  const headers = new Headers();
+
+  for (const rule of rules) {
+    if (!rule.matches.test(pathname)) continue;
+    for (const [name, value] of rule.headers) headers.set(name, value);
+  }
+
+  /*
+   * The one deliberate divergence from production: `_astro/*` and the fonts are
+   * cached for a year there, which during a local review shows up as edits that
+   * appear not to have happened. Security headers are the reason for applying
+   * this file at all; caching is not, so it is overridden rather than mirrored.
+   */
+  headers.set('Cache-Control', 'no-store');
+
+  return headers;
+};
 
 /** Resolves a URL path to a file inside `dist`, or null if it escapes the root. */
 const resolve = (pathname: string): string | null => {
@@ -41,15 +129,15 @@ const server = Bun.serve({
     const file = resolve(pathname);
 
     if (file) {
-      return new Response(Bun.file(file), {
-        headers: { 'Cache-Control': 'no-store' },
-      });
+      return new Response(Bun.file(file), { headers: headersFor(pathname) });
     }
 
     const notFound = join(ROOT, '404.html');
+    const headers = headersFor(pathname);
+    headers.set('Content-Type', 'text/html; charset=utf-8');
     return new Response(existsSync(notFound) ? Bun.file(notFound) : 'Not found', {
       status: 404,
-      headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' },
+      headers,
     });
   },
 });

--- a/src/scripts/cursor.ts
+++ b/src/scripts/cursor.ts
@@ -1,5 +1,3 @@
-import { animate } from 'motion';
-
 import { hasFinePointer, prefersReducedMotion, queryAll } from './env';
 
 /**
@@ -68,10 +66,21 @@ export const initCursor = (): void => {
 };
 
 /** Elements tagged `data-magnetic` drift toward the pointer while it is near. */
-export const initMagnetic = (): void => {
+export const initMagnetic = async (): Promise<void> => {
   if (!hasFinePointer() || prefersReducedMotion()) return;
 
-  for (const el of queryAll<HTMLElement>('[data-magnetic]')) {
+  const targets = queryAll<HTMLElement>('[data-magnetic]');
+  if (targets.length === 0) return;
+
+  /*
+   * `motion` is ~16 kB gzipped and this is the only place that reaches for it,
+   * behind a guard no touch device and no reduced-motion visitor ever passes.
+   * Importing it *after* the guard keeps it out of the entry chunk, so those
+   * visitors never download a library that could not have run for them.
+   */
+  const { animate } = await import('motion');
+
+  for (const el of targets) {
     const strength = Number(el.dataset['magnetic'] || 0.32);
 
     const onMove = (event: PointerEvent): void => {

--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -27,9 +27,15 @@ onReady(() => {
   initTilt();
   initCopy();
   initCursor();
-  initMagnetic();
   initScrollUi();
-  initSmoothScroll();
+
+  /*
+   * These two load their animation library after their own device guards, so
+   * they settle a tick later than everything above. Deliberately not awaited:
+   * nothing here depends on them, and awaiting would hold up the rest.
+   */
+  void initMagnetic();
+  void initSmoothScroll();
 
   const canvas = document.querySelector<HTMLCanvasElement>('[data-spike-field]');
   if (canvas) initSpikeField(canvas);

--- a/src/scripts/scroll.ts
+++ b/src/scripts/scroll.ts
@@ -1,10 +1,19 @@
-import Lenis from 'lenis';
-
 import { prefersReducedMotion, queryAll } from './env';
 
 /** Momentum scrolling, unless the visitor asked for reduced motion. */
-export const initSmoothScroll = (): void => {
+export const initSmoothScroll = async (): Promise<void> => {
   if (prefersReducedMotion()) return;
+
+  /*
+   * ~8 kB gzipped, and unreachable for anyone who asked for reduced motion.
+   * Importing it after the guard keeps it out of the entry chunk.
+   *
+   * The cost is that the anchor handlers below bind a moment after first paint:
+   * a hash link clicked before then takes the browser's native jump — same
+   * destination, no easing. That is a better trade than making every visitor
+   * download Lenis before the page can respond to anything.
+   */
+  const { default: Lenis } = await import('lenis');
 
   const lenis = new Lenis({
     duration: 1.05,

--- a/tests/unit/csp.test.ts
+++ b/tests/unit/csp.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  collectScriptHashes,
+  extractInlineScripts,
+  hashInlineScript,
+  SCRIPT_HASH_PLACEHOLDER,
+} from '../../scripts/lib/csp';
+
+/**
+ * `scripts/build-headers.ts` uses these to name the site's inline scripts in the
+ * Content-Security-Policy. A wrong hash is close to the worst outcome available:
+ * the browser blocks the theme bootstrap in `BaseHead.astro`, the site paints the
+ * wrong palette and then corrects itself, and nothing about the build failed.
+ * Nothing local catches that except `bun run serve` plus a real browser, so what
+ * can be pinned here is pinned here.
+ */
+
+describe('extractInlineScripts', () => {
+  it('skips external scripts and keeps inline ones', () => {
+    const html = `
+      <script type="module" src="/_astro/entry.js"></script>
+      <script>document.documentElement.dataset.theme = 'dark';</script>
+    `;
+
+    expect(extractInlineScripts(html)).toEqual([
+      "document.documentElement.dataset.theme = 'dark';",
+    ]);
+  });
+
+  it('keeps a JSON-LD block, which never executes but is still held to script-src', () => {
+    const html = '<script type="application/ld+json">{"@type":"Person"}</script>';
+
+    expect(extractInlineScripts(html)).toEqual(['{"@type":"Person"}']);
+  });
+
+  it('reproduces the body byte for byte', () => {
+    // A hash is taken over exactly what sits between the tags, so trimming the
+    // whitespace or collapsing the newlines here would produce a hash that no
+    // browser ever computes.
+    const body = '\n  const a = 1;\n\n  const b = 2;\n';
+
+    expect(extractInlineScripts(`<script>${body}</script>`)).toEqual([body]);
+  });
+
+  it('ignores an empty inline script, which needs no hash', () => {
+    expect(extractInlineScripts('<script></script>')).toEqual([]);
+  });
+
+  it('does not let one script swallow the next', () => {
+    const html = '<script>one</script><p>between</p><script>two</script>';
+
+    expect(extractInlineScripts(html)).toEqual(['one', 'two']);
+  });
+});
+
+describe('hashInlineScript', () => {
+  it('matches sha256 computed elsewhere', () => {
+    // `printf 'hello' | openssl dgst -sha256 -binary | openssl base64`
+    expect(hashInlineScript('hello')).toBe("'sha256-LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ='");
+  });
+
+  it('quotes the expression', () => {
+    /*
+     * This is not cosmetic, and it is the bug this file exists to prevent a
+     * second time. A hash-source only counts as one when quoted; bare, it parses
+     * as a *host* expression instead — which browsers silently accept when the
+     * base64 happens to look like a hostname and reject as invalid when it
+     * contains a `+`. Either way the inline script is blocked, and only half the
+     * mistake reaches the console.
+     */
+    const hash = hashInlineScript("console.log('x')");
+
+    expect(hash.startsWith("'sha256-")).toBe(true);
+    expect(hash.endsWith("'")).toBe(true);
+  });
+});
+
+describe('collectScriptHashes', () => {
+  it('deduplicates the scripts every page shares', () => {
+    // Both pages carry the same theme bootstrap and the same JSON-LD; the CSP
+    // should name each body once, not once per page.
+    const page = '<script>a</script><script>b</script>';
+
+    expect(collectScriptHashes([page, page])).toHaveLength(2);
+  });
+
+  it('sorts, so the same build writes the same header', () => {
+    const hashes = collectScriptHashes(['<script>b</script><script>a</script>']);
+
+    expect(hashes).toEqual([...hashes].sort());
+  });
+
+  it('returns nothing when there is nothing inline to name', () => {
+    expect(collectScriptHashes(['<script src="/entry.js"></script>'])).toEqual([]);
+  });
+});
+
+describe('the placeholder', () => {
+  it('is what public/_headers actually carries', () => {
+    // Guards against renaming the constant without touching the template, which
+    // would make the substitution silently find nothing to replace.
+    expect(SCRIPT_HASH_PLACEHOLDER).toBe('{{SCRIPT_HASHES}}');
+  });
+});

--- a/tests/unit/headers.test.ts
+++ b/tests/unit/headers.test.ts
@@ -2,10 +2,13 @@ import { readFileSync } from 'node:fs';
 
 import { describe, expect, it } from 'vitest';
 
+import { SCRIPT_HASH_PLACEHOLDER } from '../../scripts/lib/csp';
+
 /**
  * `public/_headers` is applied by Cloudflare, so a mistake in it is invisible to
- * `bun run serve` and to every local browser test — it only shows up once the
- * site is deployed. These assertions stand in for that gap.
+ * every local browser test — it only shows up once the site is deployed. These
+ * assertions stand in for that gap. (`bun run serve` now applies the generated
+ * `dist/_headers` too, which covers what a static read of the template cannot.)
  */
 const headers = readFileSync('public/_headers', 'utf8');
 
@@ -38,13 +41,70 @@ describe('content security policy', () => {
     expect(directives.get('img-src')).toContain('data:');
   });
 
-  it('still refuses third-party script and framing', () => {
-    expect(directives.get('script-src')?.filter((v) => v.startsWith('http'))).toEqual([]);
+  it('admits the analytics beacon and nothing else third-party', () => {
+    /*
+     * Cloudflare Web Analytics is injected into the HTML by the zone, not by this
+     * repository, so `script-src` has to name its origin (see README § Analytics).
+     * Its beacon reports to siki.moe/cdn-cgi/rum, which is why `connect-src` below
+     * is still first-party only.
+     *
+     * This started life as "refuses third-party script outright". It is narrowed
+     * rather than deleted so it keeps refusing the *second* third-party script.
+     */
+    expect(directives.get('script-src')?.filter((v) => v.startsWith('http'))).toEqual([
+      'https://static.cloudflareinsights.com/beacon.min.js',
+    ]);
+    expect(directives.get('connect-src')).toEqual(["'self'"]);
     expect(directives.get('frame-ancestors')).toEqual(["'none'"]);
     expect(directives.get('object-src')).toEqual(["'none'"]);
   });
 
+  it('names its inline scripts by hash instead of allowing them wholesale', () => {
+    // scripts/build-headers.ts substitutes the placeholder at the end of the
+    // build. Note that a CSP carrying any hash makes browsers ignore
+    // 'unsafe-inline' entirely, so leaving it in would be misleading rather than
+    // a safety net.
+    expect(directives.get('script-src')).toContain(SCRIPT_HASH_PLACEHOLDER);
+    expect(directives.get('script-src')).not.toContain("'unsafe-inline'");
+  });
+
+  it('keeps style-src loose, because Astro inlines stylesheets', () => {
+    // `inlineStylesheets: 'auto'` in astro.config.ts, plus every component
+    // `<style>` block. Not an oversight — the counterpart of the check above.
+    expect(directives.get('style-src')).toContain("'unsafe-inline'");
+  });
+
   it('defines a default-src to fall back to', () => {
     expect(directives.get('default-src')).toEqual(["'self'"]);
+  });
+});
+
+describe('transport security', () => {
+  const hsts = headers
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l.startsWith('Strict-Transport-Security:'));
+
+  it('pins HTTPS for at least a year', () => {
+    expect(hsts).toBeDefined();
+    expect(Number(/max-age=(\d+)/.exec(hsts ?? '')?.[1] ?? 0)).toBeGreaterThanOrEqual(31536000);
+  });
+
+  it('binds this hostname only, not every subdomain', () => {
+    /*
+     * `includeSubDomains` would hold every siki.moe subdomain to HTTPS for the
+     * whole max-age, so an HTTP-only one becomes unreachable for a year and the
+     * retraction is not quick — the max-age has to be lowered and then waited
+     * out. Cloudflare's dashboard guards that with an "I understand" dialog;
+     * setting it here would skip the dialog and keep the consequence.
+     */
+    expect(hsts).not.toContain('includeSubDomains');
+  });
+
+  it('stays out of the browser preload list', () => {
+    // `preload` submits the domain to a list compiled into browser binaries.
+    // Getting back off it takes months, so it is not something to acquire as a
+    // side effect of editing a header — it needs its own decision.
+    expect(hsts).not.toContain('preload');
   });
 });


### PR DESCRIPTION
## What

Three threads, measured rather than assumed.

### Entry module: 29.0 kB → 3.9 kB gzipped

`motion` was reachable only from `initMagnetic` (behind `hasFinePointer() && !prefersReducedMotion()`) and `lenis` only from `initSmoothScroll` (behind `prefersReducedMotion()`) — yet both were static imports, so every phone downloaded ~27 kB of animation library its own device had ruled out.

| Visitor | Chunks | gzipped | was |
| --- | --- | --- | --- |
| `prefers-reduced-motion: reduce` | entry + spike canvas | **5.9 kB** | 31.0 kB |
| Touch device | + Lenis | **11.3 kB** | 31.0 kB |
| Pointer-fine desktop | + Motion | 32.5 kB | 31.0 kB |

Desktop transfers slightly more in total (three chunks compress worse than one), but none of it blocks. Trade recorded in the README.

Known cost, commented in `scroll.ts`: anchor handlers bind once Lenis lands, so a hash link clicked before then takes the browser's native jump — same destination, no easing.

### `script-src` names its inline scripts by hash

`'unsafe-inline'` is gone. The hashes change with `BaseHead.astro` and `src/data/profile.ts`, so `public/_headers` carries a `{{SCRIPT_HASHES}}` placeholder and `scripts/build-headers.ts` substitutes real values into `dist/_headers` from the emitted HTML, exiting non-zero rather than writing an empty slot.

**How this fails matters:** a CSP carrying any hash makes browsers ignore `'unsafe-inline'` entirely, so a stale hash does not degrade to the old policy — it blocks the theme bootstrap, the site paints the wrong palette for a frame, and the build stays green. So `scripts/serve.ts` now applies `dist/_headers` the way Cloudflare does, which is the only way to see this locally.

That caught a real bug: hash-sources must be **quoted**. Bare, `sha256-…` parses as a *host* expression — silently accepted when it looks like a hostname, rejected as invalid when it contains `+`. Regression test in `csp.test.ts`.

### Cloudflare Web Analytics

Enabled on the zone with **automatic injection**, so the only trace in this repo is its origin in `script-src`. The beacon reports to `siki.moe/cdn-cgi/rum` (first-party, so `connect-src` stays `'self'`), Cloudflare adds SRI to the injected tag, and `*.workers.dev` is off-zone so previews are never injected — which matters, since `verify.yml` builds `dist/` once and hands the same bytes to preview and production.

Also: HSTS for a year, `Cross-Origin-Opener-Policy: same-origin`, and `interest-cohort=()` dropped now FLoC is gone. Deliberately **not** `includeSubDomains` and **not** `preload`; tests assert their absence.

## Verification

`bun run verify` clean — 0 lint/type errors, 56 tests.

Checked in a real browser against `bun run serve` (which now applies the generated headers):

| Condition | CSP violations | Console errors | Chunks requested |
| --- | --- | --- | --- |
| Desktop | none | none | entry, canvas, Motion, Lenis |
| `reducedMotion: reduce` | none | none | entry, canvas |
| iPhone 15 | none | none | entry, canvas, Lenis |
| `/404` | none | none | — |

- Theme bootstrap confirmed **executing**, not just present: `data-theme` flips from the static `dark` in the markup to `light` on a light-preference OS. This is the check that would have caught the quoting bug in production.
- Magnetic hover still animates after the dynamic import (transform tracks the pointer).
- Hashes confirmed self-maintaining: perturbing one character in the theme script changes the emitted hash and leaves the JSON-LD hash alone.
- Zone state verified live before writing the headers: no HSTS currently served (so `_headers` will be the only source, not a duplicate), and no Rocket Loader — which would rewrite inline scripts and break the hashes.

## Note

`headers.test.ts` had a tripwire refusing all third-party script. Narrowed to "the beacon and nothing else" rather than deleted, so it still catches the second one.

Web Analytics itself needs the dashboard toggle (Web Analytics → add siki.moe, keep automatic injection). Until then the `script-src` entry is simply an unused allowlist entry — nothing breaks.