### PR TITLE
Allow the beacon's origin, not its path — the versioned URL was blocked

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,8 +223,16 @@ things that the manual JS snippet does not:
   necessarily report from previews too.
 
 No cookies, no page-view sampling, and query strings are not logged. The only
-trace in this repository is `static.cloudflareinsights.com/beacon.min.js` in the
+trace in this repository is the `static.cloudflareinsights.com` origin in the
 `script-src` above.
+
+That is the origin and not the `/beacon.min.js` path the Cloudflare docs suggest,
+which is worth knowing before anyone tightens it: automatic injection appends a
+rotating version segment (`/beacon.min.js/v4513226…`), and a CSP source whose path
+does not end in `/` has to match exactly. The documented value therefore blocks
+the beacon — it did, in production, for the few minutes between v2.2.0 and
+v2.2.1. A trailing slash is not the fix either, since it would then miss the bare
+unversioned URL. `headers.test.ts` pins the origin form.
 
 Two things silently break it. An HTML response carrying `Cache-Control: public,
 no-transform` stops the injection outright — so if HTML caching is ever added to

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siki-moe",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "private": true,
   "type": "module",
   "description": "Personal site of Siqi Yang (YouSiki) — siki.moe",

--- a/public/_headers
+++ b/public/_headers
@@ -31,10 +31,18 @@
   # HTML by the zone rather than by this repository (see README.md § Analytics).
   # Its beacon reports to siki.moe/cdn-cgi/rum, so `connect-src` stays 'self'.
   #
+  # The origin is allowed rather than the `/beacon.min.js` path the Cloudflare
+  # docs suggest, because automatic injection appends a version segment —
+  # `/beacon.min.js/v4513226…` — and a CSP path not ending in `/` must match
+  # exactly. Pinning the path blocked the beacon in production. A trailing slash
+  # would then miss the bare unversioned URL, and the version rotates whenever
+  # Cloudflare ships a new beacon, so the origin is the only stable form. That
+  # host serves nothing but this script.
+  #
   # `style-src` keeps 'unsafe-inline': Astro's `inlineStylesheets: 'auto'` puts
   # small stylesheets straight into the document, and component `<style>` blocks
   # are inline by nature.
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' {{SCRIPT_HASHES}} https://static.cloudflareinsights.com/beacon.min.js; connect-src 'self'; object-src 'none'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' {{SCRIPT_HASHES}} https://static.cloudflareinsights.com; connect-src 'self'; object-src 'none'; upgrade-insecure-requests
 
 # Fingerprinted build output — safe to keep forever.
 /_astro/*

--- a/tests/unit/headers.test.ts
+++ b/tests/unit/headers.test.ts
@@ -44,15 +44,20 @@ describe('content security policy', () => {
   it('admits the analytics beacon and nothing else third-party', () => {
     /*
      * Cloudflare Web Analytics is injected into the HTML by the zone, not by this
-     * repository, so `script-src` has to name its origin (see README § Analytics).
-     * Its beacon reports to siki.moe/cdn-cgi/rum, which is why `connect-src` below
-     * is still first-party only.
+     * repository (see README § Analytics). Its beacon reports to
+     * siki.moe/cdn-cgi/rum, which is why `connect-src` below is first-party only.
+     *
+     * The *origin*, deliberately, not the `/beacon.min.js` path the Cloudflare
+     * docs suggest: automatic injection appends a rotating version segment
+     * (`/beacon.min.js/v4513226…`), and a CSP path not ending in `/` must match
+     * exactly — so the documented value blocked the beacon in production. Do not
+     * "tighten" this back to a path.
      *
      * This started life as "refuses third-party script outright". It is narrowed
-     * rather than deleted so it keeps refusing the *second* third-party script.
+     * rather than deleted so it keeps refusing the *second* third-party origin.
      */
     expect(directives.get('script-src')?.filter((v) => v.startsWith('http'))).toEqual([
-      'https://static.cloudflareinsights.com/beacon.min.js',
+      'https://static.cloudflareinsights.com',
     ]);
     expect(directives.get('connect-src')).toEqual(["'self'"]);
     expect(directives.get('frame-ancestors')).toEqual(["'none'"]);


### PR DESCRIPTION
Fixes a live breakage introduced by #269 / v2.2.0.

## The bug

v2.2.0 shipped the value Cloudflare's own [CSP guidance](https://developers.cloudflare.com/web-analytics/faq/) gives:

```
script-src … https://static.cloudflareinsights.com/beacon.min.js
```

That does not work with **automatic injection**, which points the injected tag at a *versioned* URL:

```
https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496
```

A CSP source expression whose path does not end in `/` must match **exactly**, so the versioned URL was refused. Observed on production:

```
Loading the script '…/beacon.min.js/v4513226…' violates the following Content
Security Policy directive: "script-src 'self' 'sha256-…' 'sha256-…'
https://static.cloudflareinsights.com/beacon.min.js". The action has been blocked.
```

Consequence: no analytics collected, and a CSP error in every visitor's console — while the response header looked correct, the build was green, and all 56 tests passed. Nothing in the repo could have caught it, because the injected URL is chosen by the zone at request time.

Worth noting it was also invisible to `curl`: Cloudflare skips beacon injection for non-browser user agents, so a header-and-HTML check found no beacon at all and read as "not enabled yet". Only a real browser against production surfaced it.

## The fix

Allow the **origin**. It is the only stable form:

- a trailing slash (`…/beacon.min.js/`) would then miss the bare unversioned URL;
- the version segment rotates whenever Cloudflare ships a new beacon, so no path can be pinned.

That host serves nothing but this script, so the widening is narrow in practice.

## Verification

Before shipping this time, not after. With the new header, a dynamically injected `<script>` at each URL against `bun run serve`:

| URL | Result |
| --- | --- |
| `…/beacon.min.js/v4513226…` (what CF injects) | allowed |
| `…/beacon.min.js` (bare) | allowed |

Under the v2.2.0 header the versioned one was blocked, which is the regression this reproduces and fixes.

`bun run verify` clean — 0 lint/type errors, 56 tests. `headers.test.ts` now pins the origin form with a comment explaining why it must not be re-narrowed to a path.

Version → 2.2.1.